### PR TITLE
feat: add language code suffix to output filename

### DIFF
--- a/src/subsai/__init__.py
+++ b/src/subsai/__init__.py
@@ -1,3 +1,4 @@
 from subsai.main import SubsAI, Tools
 from subsai.configs import *
+from subsai.utils import build_subtitle_path
 

--- a/src/subsai/cli.py
+++ b/src/subsai/cli.py
@@ -71,7 +71,8 @@ def run(media_file_arg: List[str],
         translation_configs,
         translation_source_lang,
         translation_target_lang,
-        output_suffix
+        output_suffix,
+        language_suffix
         ):
     files = _handle_media_file(media_file_arg)
     model_configs = _handle_configs(model_configs)
@@ -94,10 +95,13 @@ def run(media_file_arg: List[str],
                 os.makedirs(folder, exist_ok=True)
         else:
             folder = file.parent
+        # Build the output filename
+        stem = file.stem
         if output_suffix is not None:
-            file_name = folder / (file.stem + output_suffix + '.' + subs_format)
-        else:
-            file_name = folder / (file.stem + '.' + subs_format)
+            stem = stem + output_suffix
+        if language_suffix is not None:
+            stem = stem + '.' + language_suffix
+        file_name = folder / (stem + '.' + subs_format)
 
         if translation_model is not None:
             if tr_model is None:
@@ -145,6 +149,9 @@ def main():
                         help="JSON configuration (path to a json file or a direct "
                              "string)")
     parser.add_argument('-os', '--output-suffix', default=None, help="Name of the subtitles output file, (In batch processing, this will be used as a suffix to the media filename)")
+    parser.add_argument('-ls', '--language-suffix', default=None,
+                        help="Language code to insert before the file extension (e.g., 'en' produces video.en.srt). "
+                             "Useful for Plex/Jellyfin subtitle auto-detection.")
 
     args = parser.parse_args()
 
@@ -157,7 +164,8 @@ def main():
         translation_configs=args.translation_configs,
         translation_source_lang=args.translation_source_lang,
         translation_target_lang=args.translation_target_lang,
-        output_suffix=args.output_suffix)
+        output_suffix=args.output_suffix,
+        language_suffix=args.language_suffix)
 
     end_time = time.time()
     elapsed_time = end_time - start_time

--- a/src/subsai/utils.py
+++ b/src/subsai/utils.py
@@ -5,6 +5,9 @@
 Utility functions
 """
 
+import pathlib
+from typing import Optional, Union
+
 import torch
 from pysubs2.formats import FILE_EXTENSION_TO_FORMAT_IDENTIFIER
 
@@ -66,3 +69,45 @@ def available_subs_formats(include_extensions=True):
     else:
         # remove the '.' separator from extension names
         return [ext.split('.')[1] for ext in extensions]
+
+
+def build_subtitle_path(
+    media_file: Union[str, pathlib.Path],
+    subs_format: str = 'srt',
+    destination_folder: Optional[Union[str, pathlib.Path]] = None,
+    output_suffix: Optional[str] = None,
+    language_suffix: Optional[str] = None,
+) -> pathlib.Path:
+    """
+    Build the output path for a subtitle file, optionally inserting a language
+    code before the extension (e.g. ``video.en.srt``).
+
+    This is useful for media servers like Plex and Jellyfin that auto-detect
+    subtitle language from the filename pattern ``video.LANG.ext``.
+
+    :param media_file: path to the source media file
+    :param subs_format: subtitle format / extension (without dot), e.g. ``srt``
+    :param destination_folder: optional output directory (defaults to same
+        folder as *media_file*)
+    :param output_suffix: optional string appended to the stem before the
+        language code
+    :param language_suffix: ISO-639 language code to insert before the
+        extension (e.g. ``en``, ``ar``, ``ja``). If *None*, no language code
+        is added.
+
+    :return: :class:`pathlib.Path` of the subtitle file
+    """
+    media_path = pathlib.Path(media_file)
+
+    if destination_folder is not None:
+        folder = pathlib.Path(destination_folder).absolute()
+    else:
+        folder = media_path.parent
+
+    stem = media_path.stem
+    if output_suffix is not None:
+        stem = stem + output_suffix
+    if language_suffix is not None:
+        stem = stem + '.' + language_suffix
+
+    return folder / (stem + '.' + subs_format)


### PR DESCRIPTION
## Summary

- Adds `--language-suffix` / `-ls` CLI flag that inserts a language code before the file extension (e.g., `video.en.srt` instead of `video.srt`)
- Adds `build_subtitle_path()` utility function in the Python API for programmatic use
- No breaking changes -- when the flag is omitted, behavior is identical to before

## Motivation

Media servers like **Plex** and **Jellyfin** auto-detect subtitle language from the filename pattern `video.LANG.ext`. This feature lets users generate subtitles with the correct naming convention directly, without needing to rename files afterward.

Closes #172

## Usage

### CLI
```bash
# Produces: video.en.srt
subsai video.mp4 -m openai/whisper -ls en

# Works with other options
subsai video.mp4 -m openai/whisper -ls ar -f ass  # video.ar.ass
subsai video.mp4 -m openai/whisper -ls ja -os _processed  # video_processed.ja.srt
```

### Python API
```python
from subsai import build_subtitle_path

path = build_subtitle_path("video.mp4", language_suffix="en")
# => video.en.srt

path = build_subtitle_path("video.mp4", subs_format="ass", language_suffix="ar")
# => video.ar.ass
```

## Test plan

- [ ] Verify `subsai video.mp4 -ls en` produces `video.en.srt`
- [ ] Verify omitting `-ls` produces `video.srt` (no regression)
- [ ] Verify `-ls` works together with `-os` suffix and `-df` destination folder
- [ ] Verify `build_subtitle_path()` returns correct paths for various inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)