### PR TITLE
Fix temp file leaks and correct return type annotations

### DIFF
--- a/src/subsai/main.py
+++ b/src/subsai/main.py
@@ -107,7 +107,7 @@ class SubsAI:
 
         :return: SSAFile: list of subtitles
         """
-        if type(model) == str:
+        if isinstance(model, str):
             stt_model = SubsAI.create_model(model, model_config)
         else:
             stt_model = model
@@ -142,7 +142,7 @@ class Tools:
         :param model: the name of the model
         :return: list of available languages
         """
-        if type(model) == str:
+        if isinstance(model, str):
             langs = Tools.create_translation_model(model).available_languages()
         else:
             langs = model.available_languages()
@@ -180,7 +180,7 @@ class Tools:
 
         :return: returns an `SSAFile` subtitles translated to the target language
         """
-        if type(model) == str:
+        if isinstance(model, str):
             translation_model = Tools.create_translation_model(model_name=model, model_family=model_family)
         else:
             translation_model = model
@@ -240,6 +240,11 @@ class Tools:
             os.unlink(srtin_file.name)
             srtout_file.close()
             os.unlink(srtout_file.name)
+            if os.path.exists(srtin):
+                os.unlink(srtin)
+            if os.path.exists(srtout):
+                os.unlink(srtout)
+
     @staticmethod
     def merge_subs_with_video(subs: Dict[str, SSAFile],
                   media_file: str,

--- a/src/subsai/models/faster_whisper_model.py
+++ b/src/subsai/models/faster_whisper_model.py
@@ -251,7 +251,7 @@ class FasterWhisperModel(AbstractModel):
         logging.basicConfig()
         logging.getLogger("faster_whisper").setLevel(logging.DEBUG)
 
-    def transcribe(self, media_file) -> str:
+    def transcribe(self, media_file) -> SSAFile:
         segments, info = self.model.transcribe(media_file, **self.transcribe_configs)
         subs = SSAFile()
         total_duration = round(info.duration, 2)  # Same precision as the Whisper timestamps.

--- a/src/subsai/models/whisperX_model.py
+++ b/src/subsai/models/whisperX_model.py
@@ -126,7 +126,7 @@ class WhisperXModel(AbstractModel):
                                          download_root=self.download_root,
                                          language=self.language)
 
-    def transcribe(self, media_file) -> str:
+    def transcribe(self, media_file) -> SSAFile:
         audio = whisperx.load_audio(media_file)
         result = self.model.transcribe(audio, batch_size=self.batch_size)
         model_a, metadata = whisperx.load_align_model(language_code=result["language"], device=self.device)

--- a/src/subsai/models/whisper_api_model.py
+++ b/src/subsai/models/whisper_api_model.py
@@ -173,36 +173,40 @@ class WhisperAPIModel(AbstractModel):
                 os.remove(chunk_path)
             raise e
 
-    def transcribe(self, media_file: str) -> str:
+    def transcribe(self, media_file: str) -> SSAFile:
 
         audio_file_path = convert_video_to_audio_ffmpeg(media_file)
 
-        chunks = self.chunk_audio(audio_file_path)
+        try:
+            chunks = self.chunk_audio(audio_file_path)
 
-        print(f"Processing {len(chunks)} audio chunks with {self.n_jobs} parallel jobs")
+            print(f"Processing {len(chunks)} audio chunks with {self.n_jobs} parallel jobs")
 
-        # Prepare chunk data for parallel processing
-        chunk_data = [(i, chunk, offset) for i, (chunk, offset) in enumerate(chunks)]
+            # Prepare chunk data for parallel processing
+            chunk_data = [(i, chunk, offset) for i, (chunk, offset) in enumerate(chunks)]
 
-        # Use parallel processing if n_jobs > 1, otherwise process sequentially
-        if self.n_jobs > 1:
-            # Use threading backend since API calls are I/O-bound
-            parallel_results = Parallel(n_jobs=self.n_jobs, backend="threading")(
-                delayed(self._transcribe_chunk)(data) for data in chunk_data
-            )
-        else:
-            # Sequential processing for n_jobs=1
-            parallel_results = [self._transcribe_chunk(data) for data in chunk_data]
+            # Use parallel processing if n_jobs > 1, otherwise process sequentially
+            if self.n_jobs > 1:
+                # Use threading backend since API calls are I/O-bound
+                parallel_results = Parallel(n_jobs=self.n_jobs, backend="threading")(
+                    delayed(self._transcribe_chunk)(data) for data in chunk_data
+                )
+            else:
+                # Sequential processing for n_jobs=1
+                parallel_results = [self._transcribe_chunk(data) for data in chunk_data]
 
-        # Sort results by chunk index to maintain order
-        parallel_results.sort(key=lambda x: x[0])
+            # Sort results by chunk index to maintain order
+            parallel_results.sort(key=lambda x: x[0])
 
-        # Process results and apply time offsets
-        results = ""
-        for i, result_text, offset in parallel_results:
-            # Shift subtitles by offset
-            result = SSAFile.from_string(result_text)
-            result.shift(ms=offset)
-            results += result.to_string("srt")
+            # Process results and apply time offsets
+            results = ""
+            for i, result_text, offset in parallel_results:
+                # Shift subtitles by offset
+                result = SSAFile.from_string(result_text)
+                result.shift(ms=offset)
+                results += result.to_string("srt")
 
-        return SSAFile.from_string(results)
+            return SSAFile.from_string(results)
+        finally:
+            if os.path.exists(audio_file_path):
+                os.unlink(audio_file_path)

--- a/src/subsai/models/whisper_model.py
+++ b/src/subsai/models/whisper_model.py
@@ -9,6 +9,7 @@ See [openai/whisper](https://github.com/openai/whisper)
 
 from typing import Tuple
 import pysubs2
+from pysubs2 import SSAFile
 from subsai.models.abstract_model import AbstractModel
 import whisper
 from subsai.utils import _load_config, get_available_devices
@@ -203,7 +204,7 @@ class WhisperModel(AbstractModel):
                                         download_root=self.download_root,
                                         in_memory=self.in_memory)
 
-    def transcribe(self, media_file) -> str:
+    def transcribe(self, media_file) -> SSAFile:
         audio = whisper.load_audio(media_file)
         result = self.model.transcribe(audio,
                                        verbose=self.verbose,

--- a/src/subsai/models/whisper_timestamped_model.py
+++ b/src/subsai/models/whisper_timestamped_model.py
@@ -252,7 +252,7 @@ class WhisperTimeStamped(AbstractModel):
                                                     download_root=self.download_root,
                                                     in_memory=self.in_memory)
 
-    def transcribe(self, media_file) -> str:
+    def transcribe(self, media_file) -> SSAFile:
         audio = whisper_timestamped.load_audio(media_file)
         results = whisper_timestamped.transcribe(self.model, audio,
                                                  verbose=self.verbose,

--- a/src/subsai/models/whispercpp_model.py
+++ b/src/subsai/models/whispercpp_model.py
@@ -235,7 +235,7 @@ class WhisperCppModel(AbstractModel):
 
         self.model = Model(model=self.model_type, **self.params)
 
-    def transcribe(self, media_file) -> str:
+    def transcribe(self, media_file) -> SSAFile:
         segments = self.model.transcribe(media=media_file, **self.params)
         subs = SSAFile()
         for seg in segments:


### PR DESCRIPTION
## Summary

Found a few bugs while reading through the codebase -- two temp file leaks, incorrect return type annotations, and some `type() == str` checks that should be `isinstance()`.

### Bug 1: Temp file leak in `auto_sync()`

`auto_sync()` creates temp files and appends `.ass` / `.srt` extensions to them (e.g. `srtin = srtin_file.name + '.ass'`). The `finally` block was deleting the extensionless base files (`srtin_file.name`, `srtout_file.name`) but never the actual `.ass` and `.srt` files that ffsubsync writes to. Every call to `auto_sync()` leaked two files in the system temp directory.

**Fix:** Added cleanup for `srtin` and `srtout` (the paths with extensions) in the `finally` block, with `os.path.exists()` guards since they may not have been created if an error happened early.

### Bug 2: Temp file leak in `WhisperAPIModel.transcribe()`

`convert_video_to_audio_ffmpeg()` creates a temp audio file (e.g. `/tmp/filename.mp3`) but after transcription finishes, that file was never cleaned up. Repeated transcriptions would accumulate audio files in the temp directory.

**Fix:** Wrapped the transcription body in a `try/finally` that removes the converted audio file after use.

### Bug 3: Wrong `-> str` return type on `transcribe()` in 6 models

The abstract base class correctly declares `transcribe() -> SSAFile`, and all implementations actually return `SSAFile` objects. But 6 concrete model files had `-> str` as the return type annotation:
- `whisper_model.py`
- `whisper_api_model.py`
- `whisper_timestamped_model.py`
- `whisperX_model.py`
- `faster_whisper_model.py`
- `whispercpp_model.py`

**Fix:** Changed all to `-> SSAFile`. Added the missing `from pysubs2 import SSAFile` to `whisper_model.py` (the others already had it).

### Bug 4: `type(model) == str` instead of `isinstance()`

Three places in `main.py` used `type(model) == str` which won't match subclasses of `str` and is generally considered non-Pythonic.

**Fix:** Changed all three to `isinstance(model, str)`.

## Test plan

- [ ] Verify `auto_sync()` no longer leaves `.ass`/`.srt` files in temp directory after use
- [ ] Verify `WhisperAPIModel.transcribe()` cleans up the converted audio file
- [ ] Confirm type checkers (mypy/pyright) no longer flag return type mismatches on `transcribe()`
- [ ] Run existing test suite (`python -m pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)