### PR TITLE
feat: optional dependency groups for backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,26 @@ _Quoted from the official openai/whisper installation_
 * Once ffmpeg is installed, install `subsai`
 
 ```shell
-pip install git+https://github.com/absadiki/subsai
+# Install base package (no backends — lightweight, fast install)
+pip install git+https://github.com/absadiki/subsai.git
+
+# Install with a specific backend only
+pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[faster-whisper]"
+pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[whisper]"
+pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[stable-ts]"
+
+# Install multiple backends
+pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[faster-whisper,api]"
+
+# Install everything (all backends + web UI — old behavior)
+pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[all]"
+
+# Install the web UI
+pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[webui]"
 ```
+
+Available extras: `whisper`, `faster-whisper`, `stable-ts`, `whisperx`, `timestamped`, `whisper-cpp`, `transformers`, `api`, `webui`, `all`
+
 > [!NOTE]
 > * It is recommended to use Python 3.10 or 3.11. Versions 3.12 or later may have compatibility issues.
 > * If torch is unable to detect your GPU devices during your usage of subsai, assuming you have a supported GPU device, there is a chance that `pip` installed the CPU version of torch. You can install a torch version with CUDA support by following the [get started locally guide](https://pytorch.org/get-started/locally/) on pytorch.
@@ -175,9 +193,9 @@ subsai media.txt --model openai/whisper --format srt
 To install:
 1. `git clone https://github.com/absadiki/subsai`
 2. `cd subsai`
-3. `uv pip install -e .`
+3. `pip install -e ".[faster-whisper]"` (or whichever backend you need)
 
-*Note: For minimal installs or if having issues installing dependencies, you can comment the dependencies for backends you won't use in the file `requirements.txt`.*
+*Note: Install only the backends you need to avoid dependency conflicts. Use `pip install -e ".[all]"` to install everything.*
 
 ```python
 from subsai import SubsAI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,67 @@ requires-python = ">=3.8"
 keywords = ["subtitles", "openai", "whisper"]
 license = {text = "LICENSE"}
 
+dependencies = [
+    "pysubs2~=1.6.0",
+    "ffmpeg-python>=0.2.0",
+    "ffsubsync~=0.4.24",
+    "dl-translate==0.3.0",
+    "tqdm",
+    "numpy<2",
+]
 
-dynamic = ["dependencies"]
-
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
+[project.optional-dependencies]
+whisper = [
+    "openai-whisper==20240930",
+    "torch==2.2.0",
+    "torchaudio==2.2.0",
+]
+faster-whisper = [
+    "faster-whisper",
+    "openai-whisper==20240930",
+    "torch==2.2.0",
+    "torchaudio==2.2.0",
+]
+stable-ts = [
+    "stable-ts==2.18.2",
+    "faster-whisper",
+    "openai-whisper==20240930",
+    "torch==2.2.0",
+    "torchaudio==2.2.0",
+]
+whisperx = [
+    "whisperx @ git+https://github.com/m-bain/whisperx.git@8c58c54635cd6ee2d9d8665a3cf789863f6ed700",
+    "openai-whisper==20240930",
+    "torch==2.2.0",
+    "torchaudio==2.2.0",
+]
+timestamped = [
+    "whisper-timestamped @ git+https://github.com/linto-ai/whisper-timestamped",
+    "openai-whisper==20240930",
+    "torch==2.2.0",
+    "torchaudio==2.2.0",
+]
+whisper-cpp = [
+    "pywhispercpp==1.3.1",
+]
+transformers = [
+    "transformers==4.48.1",
+    "torch==2.2.0",
+]
+api = [
+    "openai==1.60.1",
+    "pydub==0.25.1",
+    "joblib>=1.5.2",
+]
+webui = [
+    "pandas==1.5.3",
+    "streamlit~=1.20.0",
+    "streamlit-player~=0.1.5",
+    "streamlit-aggrid~=0.3.4",
+]
+all = [
+    "subsai[whisper,faster-whisper,stable-ts,whisperx,timestamped,whisper-cpp,transformers,api,webui]",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/absadiki/subsai"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,46 +1,10 @@
-# always needed
-ffsubsync~=0.4.24
+# Base dependencies (always installed)
+# Backend-specific deps have moved to [project.optional-dependencies] in pyproject.toml
+# Install backends with: pip install subsai[faster-whisper], subsai[all], etc.
+
 pysubs2~=1.6.0
-dl_translate==0.3.0
-pydub==0.25.1
-
-# to avoid problem with dependencies versions
-numpy<2
-torch==2.2.0
-torchaudio==2.2.0
-
-
-# For the Web-UI
-pandas==1.5.3
-streamlit~=1.20.0
-streamlit_player~=0.1.5
-streamlit-aggrid~=0.3.4
-
-# Backend specific dependencies
-
-# openai API:
-openai==1.60.1
 ffmpeg-python>=0.2.0
-joblib>=1.5.2
-
-# whisper timestamped:
-whisper-timestamped @ git+https://github.com/linto-ai/whisper-timestamped
-
-# pywhispercpp:
-pywhispercpp==1.3.1
-
-# stable-ts and faster_whisper:
-faster_whisper
-
-# stable ts:
-stable-ts==2.18.2
-
-# whisperx:
-whisperx @ git+https://github.com/m-bain/whisperx.git@8c58c54635cd6ee2d9d8665a3cf789863f6ed700
-
-# huggingface:
-transformers==4.48.1
-
-# stable-ts, whisper, whisperx, faster_whisper, whisper-timestamped
-openai-whisper==20240930
-
+ffsubsync~=0.4.24
+dl-translate==0.3.0
+tqdm
+numpy<2

--- a/src/subsai/configs.py
+++ b/src/subsai/configs.py
@@ -5,45 +5,49 @@
 Configurations file
 """
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 from ffsubsync.constants import DEFAULT_MAX_SUBTITLE_SECONDS, DEFAULT_START_SECONDS, DEFAULT_MAX_OFFSET_SECONDS, \
     DEFAULT_APPLY_OFFSET_SECONDS, DEFAULT_FRAME_RATE, DEFAULT_VAD
 
 try:
     from subsai.models.faster_whisper_model import FasterWhisperModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("faster-whisper backend not available (install with: pip install subsai[faster-whisper])")
 try:
     from subsai.models.hugging_face_model import HuggingFaceModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("transformers backend not available (install with: pip install subsai[transformers])")
 try:
     from subsai.models.whisperX_model import WhisperXModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("whisperX backend not available (install with: pip install subsai[whisperx])")
 try:
     from subsai.models.whisper_model import WhisperModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("whisper backend not available (install with: pip install subsai[whisper])")
 try:
     from subsai.models.whisper_timestamped_model import WhisperTimeStamped
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("whisper-timestamped backend not available (install with: pip install subsai[timestamped])")
 try:
     from subsai.models.whispercpp_model import WhisperCppModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("whisper.cpp backend not available (install with: pip install subsai[whisper-cpp])")
 try:
     from subsai.utils import get_available_devices, available_translation_models
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("utils not available")
 try:
     from subsai.models.stable_ts_model import StableTsModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("stable-ts backend not available (install with: pip install subsai[stable-ts])")
 try:
     from subsai.models.whisper_api_model import WhisperAPIModel
-except ImportError as e:
-    print(e)
+except Exception:
+    _logger.debug("whisper API backend not available (install with: pip install subsai[api])")
 
 AVAILABLE_MODELS = {}
 if "WhisperModel" in locals():
@@ -116,7 +120,15 @@ if "HuggingFaceModel" in locals():
         'config_schema': HuggingFaceModel.config_schema,
     }
 if not AVAILABLE_MODELS:
-    raise Exception("subsai couldn't find any available models")
+    import warnings
+    warnings.warn(
+        "No transcription backends found. Install at least one backend, e.g.:\n"
+        "  pip install subsai[faster-whisper]\n"
+        "  pip install subsai[all]\n"
+        "Available extras: whisper, faster-whisper, stable-ts, whisperx, "
+        "timestamped, whisper-cpp, transformers, api",
+        stacklevel=2,
+    )
 
 BASIC_TOOLS_CONFIGS = {
     'set time': {


### PR DESCRIPTION
## Summary

- **Move backend-specific dependencies into `[project.optional-dependencies]`** in `pyproject.toml`, so users install only what they need instead of every backend at once
- **Keep base deps minimal**: `pysubs2`, `ffmpeg-python`, `ffsubsync`, `dl-translate`, `tqdm`, `numpy`
- **Improve error handling in `configs.py`**: broaden `except ImportError` to `except Exception` (catches `RuntimeError` from version mismatches too), replace noisy `print(e)` with `logging.debug`, downgrade fatal "no models found" error to a helpful warning with install instructions

## Problem

This is the #1 user pain point -- 12+ open issues about installation failures because ALL backends are installed even if you only need one. Dependency conflicts between `torch`, `whisperx`, `transformers`, `stable-ts`, etc. make a clean install nearly impossible on many systems.

Related issues: #132, #171, #169, #164, #116, #115, #101

## Solution

PR #176 laid the groundwork by making backends optional at import time (try/except in `configs.py`). This PR completes that work by making the **pip dependencies** optional too via extras.

### Install examples

```bash
# Base only (no backends)
pip install git+https://github.com/absadiki/subsai.git

# Single backend
pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[faster-whisper]"

# Multiple backends
pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[faster-whisper,api]"

# Everything (old behavior)
pip install "git+https://github.com/absadiki/subsai.git#egg=subsai[all]"
```

### Available extras

| Extra | Packages |
|-------|----------|
| `whisper` | openai-whisper, torch, torchaudio |
| `faster-whisper` | faster-whisper, openai-whisper, torch, torchaudio |
| `stable-ts` | stable-ts, faster-whisper, openai-whisper, torch, torchaudio |
| `whisperx` | whisperx, openai-whisper, torch, torchaudio |
| `timestamped` | whisper-timestamped, openai-whisper, torch, torchaudio |
| `whisper-cpp` | pywhispercpp |
| `transformers` | transformers, torch |
| `api` | openai, pydub, joblib |
| `webui` | streamlit, pandas, streamlit-player, streamlit-aggrid |
| `all` | all of the above |

## Test plan

- [ ] `pip install -e .` (base only) -- verify `from subsai import SubsAI` works with no backends, shows warning
- [ ] `pip install -e ".[faster-whisper]"` -- verify faster-whisper model loads
- [ ] `pip install -e ".[all]"` -- verify all models load (same as old behavior)
- [ ] Verify no noisy import errors printed to stdout when backends are missing

## Backward compatibility

- `pip install subsai[all]` reproduces the old behavior exactly
- `requirements.txt` is kept for reference but `pyproject.toml` is now the source of truth for dependencies
- The try/except pattern in `configs.py` (from PR #176) ensures missing backends are gracefully excluded

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)